### PR TITLE
composer require php:^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.0",
     "automattic/vipwpcs": "^0.4.0",
-    "wp-coding-standards/wpcs": "^1.1"
+    "wp-coding-standards/wpcs": "^1.2.1"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f209976043f2cdd407bcffa94c2b465",
+    "content-hash": "188ca8b47efd26cbc20afd2ea2d10160",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -153,12 +153,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "54ee79a17e8cdc4ff8a1570198d5bc669a5803b8"
+                "reference": "7f9676e3d324ff0745cda4f4222b194993d37d57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/54ee79a17e8cdc4ff8a1570198d5bc669a5803b8",
-                "reference": "54ee79a17e8cdc4ff8a1570198d5bc669a5803b8",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/7f9676e3d324ff0745cda4f4222b194993d37d57",
+                "reference": "7f9676e3d324ff0745cda4f4222b194993d37d57",
                 "shasum": ""
             },
             "conflict": {
@@ -253,7 +253,7 @@
                 "shopware/shopware": "<5.3.7",
                 "silverstripe/cms": ">=3,<=3.0.11|>=3.1,<3.1.11",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": ">=3,<3.3",
+                "silverstripe/framework": ">=3,<3.3|>=3.6,<3.6.7|>=3.7,<3.7.3|>=4,<4.0.7|>=4.1,<4.1.5|>=4.2,<4.2.4|>=4.3,<4.3.1",
                 "silverstripe/userforms": "<3",
                 "simple-updates/phpwhois": "<=1",
                 "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
@@ -349,7 +349,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-02-14T08:06:11+00:00"
+            "time": "2019-02-19T07:02:29+00:00"
         }
     ],
     "aliases": [],
@@ -360,7 +360,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Because wp.org svn pre-commit hook rejects PHP7.1+ syntax.