### PR TITLE
Remove redundant rules

### DIFF
--- a/Itineris/ruleset.xml
+++ b/Itineris/ruleset.xml
@@ -91,10 +91,6 @@
         <exclude name="WordPress.NamingConventions.ValidHookName" />
         <exclude name="WordPress.NamingConventions.ValidVariableName" />
         <exclude name="WordPress.PHP.DisallowShortTernary" />
-        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
-        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterCloseParenthesis" />
-        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
-        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
         <exclude name="WordPress.WhiteSpace" />
         <exclude name="WordPress.WP.EnqueuedResourceParameters.MissingVersion" />
     </rule>


### PR DESCRIPTION
`WordPress.WhiteSpace` excludes all sniffs. Maybe I'm wrong.
https://github.com/WordPress/WordPress-Coding-Standards/tree/develop/WordPress/Sniffs/WhiteSpace