### PR TITLE
Remove PSR-2

### DIFF
--- a/Itineris/ruleset.xml
+++ b/Itineris/ruleset.xml
@@ -2,7 +2,6 @@
 <ruleset name="Itineris" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
     <description>Itineris WordPress Coding Standards</description>
 
-    <rule ref="PSR2" />
     <rule ref="PSR12">
         <exclude name="PSR12.Files.FileHeader" />
     </rule>


### PR DESCRIPTION
PSR-12 replaces PSR-2.

> This specification extends, expands and replaces [PSR-2](https://www.php-fig.org/psr/psr-2/)

from https://www.php-fig.org/psr/psr-12/