### PR TITLE
Remove PSR-s from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 [Itineris WP Coding Standards](https://github.com/ItinerisLtd/itineris-wp-coding-standards) is a project with rulesets for code style and quality tools to be used in Itineris WordPress projects.
 
-It is a mix of [PSR-1](https://www.php-fig.org/psr/psr-1/), [PSR-2](https://www.php-fig.org/psr/psr-2), [PSR-4](https://www.php-fig.org/psr/psr-4/), [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), [Slevomat](https://github.com/slevomat/coding-standard) and [WordPress](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) coding standards.
+It is a mix of [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), [Slevomat](https://github.com/slevomat/coding-standard) and [WordPress coding standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards).
 
 Whenever there's a conflict between PSR and WPCS, always prefer PSR.
 


### PR DESCRIPTION
PSR-1 and PSR-2 are replaced by PSR-12.
PSR-4 is not a coding standard, it is about class autoloading.

related to #43